### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Want to join the community or have a question? Join us at the [ErsatzTV Communit
 - Channel-specific streaming mode (MPEG-TS or HLS) and transcoding settings
 - Collection-based scheduling, with collections containing television shows, seasons, episodes and movies
 - Powerful scheduling options such as chronological collection playback throughout the day or over multiple days
-- [Hardware-accelerated transcoding](#Hardware-Transcoding) options (QSV, NVENC, VAAPI)
+- Hardware-accelerated transcoding options (QSV, NVENC, VAAPI)
 - [Plex](https://www.plex.tv/) media and metadata
 - [Jellyfin](https://jellyfin.org/) media and metadata
 - [Emby](https://emby.media/) media and metadata


### PR DESCRIPTION
Remove the link for Hardware-accelerated transcoding which was just linking back to itself