### PR TITLE
upgrade to ffmpeg 7 in all docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `Something.en.forced.srt`
   - `Something.en.sdh.srt`
 
+### Changed
+- Use ffmpeg 7 in all docker images 
+
 ## [0.8.6-beta] - 2024-04-03
 ### Added
 - Add `show_studio` and `show_content_rating` to search index for seasons and episodes

--- a/ErsatzTV.Infrastructure/Health/Checks/FFmpegVersionHealthCheck.cs
+++ b/ErsatzTV.Infrastructure/Health/Checks/FFmpegVersionHealthCheck.cs
@@ -8,8 +8,8 @@ namespace ErsatzTV.Infrastructure.Health.Checks;
 
 public class FFmpegVersionHealthCheck : BaseHealthCheck, IFFmpegVersionHealthCheck
 {
-    private const string BundledVersion = "6.1";
-    private const string BundledVersionVaapi = "6.1";
+    private const string BundledVersion = "7.0";
+    private const string BundledVersionVaapi = "7.0";
     private const string WindowsVersionPrefix = "n6.1";
 
     private static readonly string[] FFmpegVersionArguments = { "-version" };

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,9 @@
-﻿# https://hub.docker.com/_/microsoft-dotnet
+﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-amd64 AS dotnet-runtime
+
+FROM jasongdove/ersatztv-ffmpeg:7.0 AS runtime-base
+COPY --from=dotnet-runtime /usr/share/dotnet /usr/share/dotnet
+
+# https://hub.docker.com/_/microsoft-dotnet
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 RUN apt-get update && apt-get install -y ca-certificates gnupg
 WORKDIR /source
@@ -35,7 +40,7 @@ RUN sed -i '/Scanner/d' ErsatzTV.csproj
 RUN dotnet publish ErsatzTV.csproj -c release -o /app -r linux-x64 --self-contained false --no-restore /p:DebugType=Embedded /p:InformationalVersion=${INFO_VERSION}
 
 # final stage/image
-FROM jasongdove/ersatztv-ffmpeg:6.1 AS runtime-base
+FROM runtime-base
 ENV FONTCONFIG_PATH=/etc/fonts
 RUN fc-cache update
 WORKDIR /app

--- a/docker/arm32v7/Dockerfile
+++ b/docker/arm32v7/Dockerfile
@@ -1,6 +1,6 @@
 ﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-arm32v7 AS dotnet-runtime
 
-FROM jasongdove/ersatztv-ffmpeg:6.1-arm AS runtime-base
+FROM jasongdove/ersatztv-ffmpeg:7.0-arm AS runtime-base
 COPY --from=dotnet-runtime /usr/share/dotnet /usr/share/dotnet
 
 # https://hub.docker.com/_/microsoft-dotnet

--- a/docker/arm64/Dockerfile
+++ b/docker/arm64/Dockerfile
@@ -1,6 +1,6 @@
 ﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-arm64v8 AS dotnet-runtime
 
-FROM jasongdove/ersatztv-ffmpeg:6.1-arm64 AS runtime-base
+FROM jasongdove/ersatztv-ffmpeg:7.0-arm64 AS runtime-base
 COPY --from=dotnet-runtime /usr/share/dotnet /usr/share/dotnet
 
 # https://hub.docker.com/_/microsoft-dotnet

--- a/docker/nvidia/Dockerfile
+++ b/docker/nvidia/Dockerfile
@@ -1,6 +1,4 @@
-﻿# https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
-RUN apt-get update && apt-get install -y ca-certificates gnupg
+﻿FROM jasongdove/ersatztv-ffmpeg:7.0-nvidia AS runtime-base
 
 RUN wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
     dpkg -i packages-microsoft-prod.deb && \
@@ -9,6 +7,10 @@ RUN wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-p
     apt-get install -yq aspnetcore-runtime-8.0 && \
     apt-get autoremove -y && \
     apt-get clean -y
+
+# https://hub.docker.com/_/microsoft-dotnet
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+RUN apt-get update && apt-get install -y ca-certificates gnupg
 
 WORKDIR /source
 
@@ -44,11 +46,10 @@ RUN sed -i '/Scanner/d' ErsatzTV.csproj
 RUN dotnet publish ErsatzTV.csproj --framework net8.0 -c release -o /app -r linux-x64 --self-contained false --no-restore /p:DebugType=Embedded /p:InformationalVersion=${INFO_VERSION}
 
 # final stage/image
-FROM jasongdove/ersatztv-ffmpeg:7.0-nvidia AS runtime-base
+FROM runtime-base
 ENV FONTCONFIG_PATH=/etc/fonts
 RUN fc-cache update
 WORKDIR /app
 EXPOSE 8409
-COPY --from=build /usr/share/dotnet /usr/share/dotnet
 COPY --from=build /app ./
 ENTRYPOINT ["./ErsatzTV"]

--- a/docker/nvidia/Dockerfile
+++ b/docker/nvidia/Dockerfile
@@ -1,6 +1,15 @@
 ﻿# https://hub.docker.com/_/microsoft-dotnet
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 RUN apt-get update && apt-get install -y ca-certificates gnupg
+
+RUN wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
+    dpkg -i packages-microsoft-prod.deb && \
+    rm packages-microsoft-prod.deb && \
+    apt-get -yqq update && \
+    apt-get install -yq aspnetcore-runtime-8.0 && \
+    apt-get autoremove -y && \
+    apt-get clean -y
+
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
@@ -35,10 +44,11 @@ RUN sed -i '/Scanner/d' ErsatzTV.csproj
 RUN dotnet publish ErsatzTV.csproj --framework net8.0 -c release -o /app -r linux-x64 --self-contained false --no-restore /p:DebugType=Embedded /p:InformationalVersion=${INFO_VERSION}
 
 # final stage/image
-FROM jasongdove/ersatztv-ffmpeg:6.1-nvidia AS runtime-base
+FROM jasongdove/ersatztv-ffmpeg:7.0-nvidia AS runtime-base
 ENV FONTCONFIG_PATH=/etc/fonts
 RUN fc-cache update
 WORKDIR /app
 EXPOSE 8409
+COPY --from=build /usr/share/dotnet /usr/share/dotnet
 COPY --from=build /app ./
 ENTRYPOINT ["./ErsatzTV"]

--- a/docker/vaapi/Dockerfile
+++ b/docker/vaapi/Dockerfile
@@ -1,4 +1,9 @@
-﻿# https://hub.docker.com/_/microsoft-dotnet
+﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-amd64 AS dotnet-runtime
+
+FROM jasongdove/ersatztv-ffmpeg:7.0-vaapi AS runtime-base
+COPY --from=dotnet-runtime /usr/share/dotnet /usr/share/dotnet
+
+# https://hub.docker.com/_/microsoft-dotnet
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 RUN apt-get update && apt-get install -y ca-certificates gnupg
 WORKDIR /source
@@ -35,7 +40,7 @@ RUN sed -i '/Scanner/d' ErsatzTV.csproj
 RUN dotnet publish ErsatzTV.csproj -c release -o /app -r linux-x64 --self-contained false --no-restore /p:DebugType=Embedded /p:InformationalVersion=${INFO_VERSION}
 
 # final stage/image
-FROM jasongdove/ersatztv-ffmpeg:6.1-vaapi AS runtime-base
+FROM runtime-base
 ENV FONTCONFIG_PATH=/etc/fonts
 RUN fc-cache update
 WORKDIR /app


### PR DESCRIPTION
This also installs the dotnet runtime in these Dockerfiles since it was removed from the base images with https://github.com/ErsatzTV/ErsatzTV-ffmpeg/pull/13