### PR TITLE
revert vaapi docker to ffmpeg 6.1

### DIFF
--- a/ErsatzTV.Infrastructure/Health/Checks/FFmpegVersionHealthCheck.cs
+++ b/ErsatzTV.Infrastructure/Health/Checks/FFmpegVersionHealthCheck.cs
@@ -9,7 +9,7 @@ namespace ErsatzTV.Infrastructure.Health.Checks;
 public class FFmpegVersionHealthCheck : BaseHealthCheck, IFFmpegVersionHealthCheck
 {
     private const string BundledVersion = "7.0";
-    private const string BundledVersionVaapi = "7.0";
+    private const string BundledVersionVaapi = "6.1";
     private const string WindowsVersionPrefix = "n6.1";
 
     private static readonly string[] FFmpegVersionArguments = { "-version" };

--- a/docker/vaapi/Dockerfile
+++ b/docker/vaapi/Dockerfile
@@ -1,7 +1,7 @@
-﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-amd64 AS dotnet-runtime
+﻿#FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-amd64 AS dotnet-runtime
 
-FROM jasongdove/ersatztv-ffmpeg:7.0-vaapi AS runtime-base
-COPY --from=dotnet-runtime /usr/share/dotnet /usr/share/dotnet
+FROM jasongdove/ersatztv-ffmpeg:6.1-vaapi AS runtime-base
+#COPY --from=dotnet-runtime /usr/share/dotnet /usr/share/dotnet
 
 # https://hub.docker.com/_/microsoft-dotnet
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build


### PR DESCRIPTION
User reported errors started with ffmpeg 7.0, such as

> HLS Process for channel 5 has terminated unsuccessfully with exit code 244: [fc#0 @ 0x561260346280] Error while filtering: Cannot allocate memory