### PR TITLE
segmenter v2 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix MySql database migrations
 - Fix Plex library scans with MySql/MariaDB
 - Fix block playout playback when no deco is configured
+- Fix `HLS Segmenter V2` to delete old segments (use less disk space while channel is active)
 
 ### Changed
 - Use ffmpeg 7 in all docker images 
@@ -88,6 +89,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Using accurate BANDWIDTH value in multi-variant playlist
   - Using proper MIME types for statically-served `.m3u8` and `.ts` files
   - Serving playlists with gzip compression
+- Use `HLS Segmenter V2` for channel preview when channel is configured for `HLS Segmenter V2`
 
 ## [0.8.6-beta] - 2024-04-03
 ### Added

--- a/ErsatzTV.FFmpeg/OutputFormat/OutputFormatConcatHls.cs
+++ b/ErsatzTV.FFmpeg/OutputFormat/OutputFormatConcatHls.cs
@@ -37,7 +37,7 @@ public class OutputFormatConcatHls : IPipelineStep
                 "-f", "hls",
                 "-hls_segment_type", segmentType,
                 //"-hls_init_time", "2",
-                "-hls_playlist_type", "event",
+                //"-hls_playlist_type", "event",
                 "-hls_time", $"{OutputFormatHls.SegmentSeconds}",
                 "-hls_list_size", "25", // burst of 45 means ~12 segments, so allow that plus a handful
                 "-segment_list_flags", "+live",

--- a/ErsatzTV.Scanner/ErsatzTV.Scanner.csproj
+++ b/ErsatzTV.Scanner/ErsatzTV.Scanner.csproj
@@ -42,8 +42,4 @@
         </AssemblyAttribute>
     </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="Application\Streaming\" />
-    </ItemGroup>
-
 </Project>

--- a/ErsatzTV/Pages/Channels.razor
+++ b/ErsatzTV/Pages/Channels.razor
@@ -176,7 +176,12 @@
 
             var uri = new UriBuilder(NavigationManager.ToAbsoluteUri(NavigationManager.Uri));
             uri.Path = uri.Path.Replace("/channels", $"/iptv/channel/{channel.Number}.m3u8");
-            uri.Query = "?mode=segmenter";
+            uri.Query = channel.StreamingMode switch
+            {
+                StreamingMode.HttpLiveStreamingSegmenterV2 => "?mode=segmenter-v2",
+                _ => "?mode=segmenter"
+            };
+
             if (JwtHelper.IsEnabled)
             {
                 uri.Query += $"&access_token={JwtHelper.GenerateToken()}";


### PR DESCRIPTION
FFmpeg will not delete segments for an event playlist, so this removes that option.