### PR TITLE
fix duration scheduling bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - When this happens, mid-roll will be treated as post-roll
 - Fix VAAPI decoder capability check
   - This caused some streams to incorrectly use software decoding
+- Fix scheduling loop/failure caused by some duration schedule items
 
 ### Changed
 - Use ffmpeg 7 in all docker images

--- a/ErsatzTV.Core/Scheduling/PlayoutModeSchedulerDuration.cs
+++ b/ErsatzTV.Core/Scheduling/PlayoutModeSchedulerDuration.cs
@@ -21,7 +21,8 @@ public class PlayoutModeSchedulerDuration : PlayoutModeSchedulerBase<ProgramSche
         CancellationToken cancellationToken)
     {
         // Logger.LogDebug(
-        //     "DurationSchedule: {CurrentTime} {DurationFinish} {InDurationFiller} {HardStop}",
+        //     "DurationSchedule: {ItemId} {CurrentTime} {DurationFinish} {InDurationFiller} {HardStop}",
+        //     scheduleItem.Id,
         //     playoutBuilderState.CurrentTime,
         //     playoutBuilderState.DurationFinish,
         //     playoutBuilderState.InDurationFiller,


### PR DESCRIPTION
`DurationFinish` was kept on some anchors even though the time had already passed, preventing the duration schedule item from ever scheduling anything again.