### PR TITLE
fix video_bit_depth search field for plex media

### DIFF
--- a/ErsatzTV.Infrastructure/Search/ElasticSearchIndex.cs
+++ b/ErsatzTV.Infrastructure/Search/ElasticSearchIndex.cs
@@ -46,7 +46,7 @@ public class ElasticSearchIndex : ISearchIndex
         return exists.IsValidResponse;
     }
 
-    public int Version => 43;
+    public int Version => 44;
 
     public async Task<bool> Initialize(
         ILocalFileSystem localFileSystem,
@@ -908,6 +908,11 @@ public class ElasticSearchIndex : ISearchIndex
                 foreach (IPixelFormat pixelFormat in maybePixelFormat)
                 {
                     doc.VideoBitDepth = pixelFormat.BitDepth;
+                }
+
+                if (maybePixelFormat.IsNone && videoStream.BitsPerRawSample > 0)
+                {
+                    doc.VideoBitDepth = videoStream.BitsPerRawSample;
                 }
 
                 var colorParams = new ColorParams(

--- a/ErsatzTV.Infrastructure/Search/LuceneSearchIndex.cs
+++ b/ErsatzTV.Infrastructure/Search/LuceneSearchIndex.cs
@@ -110,7 +110,7 @@ public sealed class LuceneSearchIndex : ISearchIndex
         return Task.FromResult(directoryExists && fileExists);
     }
 
-    public int Version => 43;
+    public int Version => 44;
 
     public async Task<bool> Initialize(
         ILocalFileSystem localFileSystem,
@@ -1393,6 +1393,11 @@ public sealed class LuceneSearchIndex : ISearchIndex
                 foreach (IPixelFormat pixelFormat in maybePixelFormat)
                 {
                     doc.Add(new Int32Field(VideoBitDepthField, pixelFormat.BitDepth, Field.Store.NO));
+                }
+
+                if (maybePixelFormat.IsNone && videoStream.BitsPerRawSample > 0)
+                {
+                    doc.Add(new Int32Field(VideoBitDepthField, videoStream.BitsPerRawSample, Field.Store.NO));
                 }
 
                 var colorParams = new ColorParams(


### PR DESCRIPTION
The `video_bith_depth` search field was previously sourced only from pixel format, which is not provided by Plex. This falls back to the Plex-provided bit depth so we can properly search/filter Plex media.