### PR TITLE
use ffmpeg 6.1 everywhere instead of ffmpeg 7

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -178,7 +178,7 @@ jobs:
         id: downloadffmpeg
         name: Download ffmpeg
         with:
-          url: "https://github.com/ErsatzTV/ErsatzTV-ffmpeg/releases/download/7.0-working-cuvid/ffmpeg-7.0-working-cuvid.7z"
+          url: "https://github.com/ErsatzTV/ErsatzTV-ffmpeg/releases/download/6.1-working-cuvid/ffmpeg-6.1-working-cuvid.7z"
           target: ffmpeg/
 
       - name: Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix template and deco template editors with MariaDB/MySql backend
 
 ### Changed
-- Use ffmpeg 7 in all docker images
 - Show health checks at top of home page; scroll release notes if needed
 - Improve `HLS Segmenter V2` compliance by:
   - Serving fmp4 segments when `hevc` video format is selected

--- a/ErsatzTV.Infrastructure/Health/Checks/FFmpegVersionHealthCheck.cs
+++ b/ErsatzTV.Infrastructure/Health/Checks/FFmpegVersionHealthCheck.cs
@@ -8,9 +8,9 @@ namespace ErsatzTV.Infrastructure.Health.Checks;
 
 public class FFmpegVersionHealthCheck : BaseHealthCheck, IFFmpegVersionHealthCheck
 {
-    private const string BundledVersion = "7.0";
-    private const string BundledVersionVaapi = "N-115388-ge9197db4f7";
-    private const string WindowsVersionPrefix = "n7.0";
+    private const string BundledVersion = "6.1";
+    private const string BundledVersionVaapi = "6.1";
+    private const string WindowsVersionPrefix = "n6.1";
 
     private static readonly string[] FFmpegVersionArguments = { "-version" };
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 ﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-amd64 AS dotnet-runtime
 
-FROM jasongdove/ersatztv-ffmpeg:7.0 AS runtime-base
+FROM jasongdove/ersatztv-ffmpeg:6.1 AS runtime-base
 COPY --from=dotnet-runtime /usr/share/dotnet /usr/share/dotnet
 
 # https://hub.docker.com/_/microsoft-dotnet

--- a/docker/arm32v7/Dockerfile
+++ b/docker/arm32v7/Dockerfile
@@ -1,6 +1,6 @@
 ﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-arm32v7 AS dotnet-runtime
 
-FROM jasongdove/ersatztv-ffmpeg:7.0-arm AS runtime-base
+FROM jasongdove/ersatztv-ffmpeg:6.1-arm AS runtime-base
 COPY --from=dotnet-runtime /usr/share/dotnet /usr/share/dotnet
 
 # https://hub.docker.com/_/microsoft-dotnet

--- a/docker/arm64/Dockerfile
+++ b/docker/arm64/Dockerfile
@@ -1,6 +1,6 @@
 ﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-arm64v8 AS dotnet-runtime
 
-FROM jasongdove/ersatztv-ffmpeg:7.0-arm64 AS runtime-base
+FROM jasongdove/ersatztv-ffmpeg:6.1-arm64 AS runtime-base
 COPY --from=dotnet-runtime /usr/share/dotnet /usr/share/dotnet
 
 # https://hub.docker.com/_/microsoft-dotnet

--- a/docker/nvidia/Dockerfile
+++ b/docker/nvidia/Dockerfile
@@ -1,4 +1,4 @@
-﻿FROM jasongdove/ersatztv-ffmpeg:7.0-nvidia AS runtime-base
+﻿FROM jasongdove/ersatztv-ffmpeg:6.1-nvidia AS runtime-base
 
 RUN wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
     dpkg -i packages-microsoft-prod.deb && \

--- a/docker/vaapi/Dockerfile
+++ b/docker/vaapi/Dockerfile
@@ -1,6 +1,6 @@
 ﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-amd64 AS dotnet-runtime
 
-FROM jasongdove/ersatztv-ffmpeg:7.0-vaapi AS runtime-base
+FROM jasongdove/ersatztv-ffmpeg:6.1-vaapi AS runtime-base
 COPY --from=dotnet-runtime /usr/share/dotnet /usr/share/dotnet
 
 # https://hub.docker.com/_/microsoft-dotnet


### PR DESCRIPTION
There have been a number of regressions observed since the upgrade from ffmpeg 6.1 => ffmpeg 7.0; so for now, let's downgrade and get the next release out the door.