### PR TITLE
add database cleaner

### DIFF
--- a/ErsatzTV.Core.Tests/Scheduling/PlaylistEnumeratorTests.cs
+++ b/ErsatzTV.Core.Tests/Scheduling/PlaylistEnumeratorTests.cs
@@ -60,6 +60,7 @@ public class PlaylistEnumeratorTests
             repo,
             playlistItemMap,
             new CollectionEnumeratorState(),
+            shufflePlaylistItems: false,
             CancellationToken.None);
 
         enumerator.MoveNext();
@@ -123,6 +124,7 @@ public class PlaylistEnumeratorTests
             repo,
             playlistItemMap,
             new CollectionEnumeratorState(),
+            shufflePlaylistItems: false,
             CancellationToken.None);
 
         enumerator.MoveNext();

--- a/ErsatzTV.Core/Domain/MediaItem/MediaItem.cs
+++ b/ErsatzTV.Core/Domain/MediaItem/MediaItem.cs
@@ -1,6 +1,6 @@
 ﻿namespace ErsatzTV.Core.Domain;
 
-public class MediaItem
+public abstract class MediaItem
 {
     public int Id { get; set; }
     public int LibraryPathId { get; set; }

--- a/ErsatzTV.Core/SystemStartup.cs
+++ b/ErsatzTV.Core/SystemStartup.cs
@@ -3,11 +3,13 @@ namespace ErsatzTV.Core;
 public class SystemStartup : IDisposable
 {
     private readonly SemaphoreSlim _databaseStartup = new(0, 100);
+    private readonly SemaphoreSlim _databaseCleaned = new(0, 100);
     private readonly SemaphoreSlim _searchIndexStartup = new(0, 100);
 
     private bool _disposedValue;
 
     public bool IsDatabaseReady { get; private set; }
+    public bool IsDatabaseCleaned { get; private set; }
     public bool IsSearchIndexReady { get; private set; }
 
     public void Dispose()
@@ -17,10 +19,14 @@ public class SystemStartup : IDisposable
     }
 
     public event EventHandler OnDatabaseReady;
+    public event EventHandler OnDatabaseCleaned;
     public event EventHandler OnSearchIndexReady;
 
     public async Task WaitForDatabase(CancellationToken cancellationToken) =>
         await _databaseStartup.WaitAsync(cancellationToken);
+
+    public async Task WaitForDatabaseCleaned(CancellationToken cancellationToken) =>
+        await _databaseCleaned.WaitAsync(cancellationToken);
 
     public async Task WaitForSearchIndex(CancellationToken cancellationToken) =>
         await _searchIndexStartup.WaitAsync(cancellationToken);
@@ -30,6 +36,13 @@ public class SystemStartup : IDisposable
         _databaseStartup.Release(100);
         IsDatabaseReady = true;
         OnDatabaseReady?.Invoke(this, EventArgs.Empty);
+    }
+
+    public void DatabaseIsCleaned()
+    {
+        _databaseCleaned.Release(100);
+        IsDatabaseCleaned = true;
+        OnDatabaseCleaned?.Invoke(this, EventArgs.Empty);
     }
 
     public void SearchIndexIsReady()
@@ -46,6 +59,7 @@ public class SystemStartup : IDisposable
             if (disposing)
             {
                 _databaseStartup.Dispose();
+                _databaseCleaned.Dispose();
                 _searchIndexStartup.Dispose();
             }
 

--- a/ErsatzTV.Infrastructure/Health/Checks/UnavailableHealthCheck.cs
+++ b/ErsatzTV.Infrastructure/Health/Checks/UnavailableHealthCheck.cs
@@ -50,7 +50,9 @@ public class UnavailableHealthCheck : BaseHealthCheck, IUnavailableHealthCheck
             .Include(mi => (mi as Show).ShowMetadata)
             .Include(mi => (mi as Season).Show)
             .ThenInclude(s => s.ShowMetadata)
-            .Include(mi => (mi as Season).SeasonMetadata);
+            .Include(mi => (mi as Season).SeasonMetadata)
+            .Include(mi => (mi as Image).MediaVersions)
+            .ThenInclude(mv => mv.MediaFiles);
 
         List<MediaItem> five = await mediaItems
             .OrderBy(mi => mi.Id)

--- a/ErsatzTV/Services/RunOnce/DatabaseCleanerService.cs
+++ b/ErsatzTV/Services/RunOnce/DatabaseCleanerService.cs
@@ -1,0 +1,50 @@
+using Dapper;
+using ErsatzTV.Core;
+using ErsatzTV.Infrastructure.Data;
+
+namespace ErsatzTV.Services.RunOnce;
+
+public class DatabaseCleanerService(
+    IServiceScopeFactory serviceScopeFactory,
+    ILogger<DatabaseCleanerService> logger,
+    SystemStartup systemStartup)
+    : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await Task.Yield();
+
+        await systemStartup.WaitForDatabase(stoppingToken);
+        if (stoppingToken.IsCancellationRequested)
+        {
+            return;
+        }
+
+        logger.LogInformation("Cleaning database");
+
+        using IServiceScope scope = serviceScopeFactory.CreateScope();
+        await using TvContext dbContext = scope.ServiceProvider.GetRequiredService<TvContext>();
+
+        // some old version deleted items in a way that MediaItem was left over without
+        // any corresponding Movie/Show/etc.
+        // this cleans out that old invalid data
+        await dbContext.Connection.ExecuteAsync(
+            """
+            delete
+            from MediaItem
+            where Id not in (select Id from Movie)
+              and Id not in (select Id from Show)
+              and Id not in (select Id from Season)
+              and Id not in (select Id from Episode)
+              and Id not in (select Id from OtherVideo)
+              and Id not in (select Id from MusicVideo)
+              and Id not in (select Id from Song)
+              and Id not in (select Id from Artist)
+              and Id not in (select Id from Image)
+            """);
+
+        systemStartup.DatabaseIsCleaned();
+
+        logger.LogInformation("Done cleaning database");
+    }
+}

--- a/ErsatzTV/Services/RunOnce/RebuildSearchIndexService.cs
+++ b/ErsatzTV/Services/RunOnce/RebuildSearchIndexService.cs
@@ -25,6 +25,12 @@ public class RebuildSearchIndexService : BackgroundService
             return;
         }
 
+        await _systemStartup.WaitForDatabaseCleaned(stoppingToken);
+        if (stoppingToken.IsCancellationRequested)
+        {
+            return;
+        }
+
         using IServiceScope scope = _serviceScopeFactory.CreateScope();
         IMediator mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
         await mediator.Send(new RebuildSearchIndex(), stoppingToken);

--- a/ErsatzTV/Startup.cs
+++ b/ErsatzTV/Startup.cs
@@ -710,6 +710,7 @@ public class Startup
         // run-once/blocking startup services
         services.AddHostedService<EndpointValidatorService>();
         services.AddHostedService<DatabaseMigratorService>();
+        services.AddHostedService<DatabaseCleanerService>();
         services.AddHostedService<LoadLoggingLevelService>();
         services.AddHostedService<CacheCleanerService>();
         services.AddHostedService<ResourceExtractorService>();


### PR DESCRIPTION
Some previous version deleted media items in a way where only the `MediaItem` record remained in the database, and not the corresponding `Movie`/`Episode`/etc. record.

This adds a service to delete those invalid (and unusable) items from the database on startup, which has the side effect of fixing the `Unavailable` health check which crashed due to these items.

`MediaItem` has been made abstract to force this issue to the surface should it happen again in the future.