### PR TITLE
[scheduling] Add a new mode RandomRotation that randomly picks an item from a randomly choosen group (show/artist) for block schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add `Random Count` filler mode by @embolon
   - This mode will randomly schedule between zero and the provided count number of items
   - e.g. random count 3 will schedule between 0 and 3 filler items
+- Add `Random Rotation` playback order for block scheduling by @embolon
+  - This playback order will pick a random item from a randomly selected group (show or artist)
+  - It is somewhat similar to the `Fill With Group` mode used in flood scheduling
 
 ### Fixed
 - Add basic cache busting to XMLTV image URLs

--- a/ErsatzTV.Application/ErsatzTV.Application.csproj
+++ b/ErsatzTV.Application/ErsatzTV.Application.csproj
@@ -12,7 +12,7 @@
       <PackageReference Include="Bugsnag" Version="3.1.0" />
       <PackageReference Include="CliWrap" Version="3.6.6" />
       <PackageReference Include="Humanizer.Core" Version="2.14.1" />
-      <PackageReference Include="MediatR" Version="12.4.0" />
+      <PackageReference Include="MediatR" Version="12.4.1" />
       <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
       <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20">

--- a/ErsatzTV.Application/ProgramSchedules/Commands/ProgramScheduleItemCommandBase.cs
+++ b/ErsatzTV.Application/ProgramSchedules/Commands/ProgramScheduleItemCommandBase.cs
@@ -57,6 +57,7 @@ public abstract class ProgramScheduleItemCommandBase
                 case PlaybackOrder.Random:
                 case PlaybackOrder.MultiEpisodeShuffle:
                 case PlaybackOrder.SeasonEpisode:
+                case PlaybackOrder.RandomRotation:
                     return BaseError.New($"Invalid playback order for multi collection: '{item.PlaybackOrder}'");
                 case PlaybackOrder.Shuffle:
                 case PlaybackOrder.ShuffleInOrder:

--- a/ErsatzTV.Core.Tests/ErsatzTV.Core.Tests.csproj
+++ b/ErsatzTV.Core.Tests/ErsatzTV.Core.Tests.csproj
@@ -9,14 +9,14 @@
     <ItemGroup>
       <PackageReference Include="Bugsnag" Version="3.1.0" />
       <PackageReference Include="CliWrap" Version="3.6.6" />
-      <PackageReference Include="FluentAssertions" Version="6.12.0" />
+      <PackageReference Include="FluentAssertions" Version="6.12.1" />
       <PackageReference Include="LanguageExt.Core" Version="4.4.9" />
       <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
       <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
       <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ErsatzTV.Core/Domain/PlaybackOrder.cs
+++ b/ErsatzTV.Core/Domain/PlaybackOrder.cs
@@ -7,5 +7,6 @@ public enum PlaybackOrder
     Shuffle = 3,
     ShuffleInOrder = 4,
     MultiEpisodeShuffle = 5,
-    SeasonEpisode = 6
+    SeasonEpisode = 6,
+    RandomRotation = 7
 }

--- a/ErsatzTV.Core/ErsatzTV.Core.csproj
+++ b/ErsatzTV.Core/ErsatzTV.Core.csproj
@@ -14,7 +14,7 @@
       <PackageReference Include="Flurl" Version="4.0.0" />
       <PackageReference Include="LanguageExt.Core" Version="4.4.9" />
       <PackageReference Include="LanguageExt.Transformers" Version="4.4.8" />
-      <PackageReference Include="MediatR" Version="12.4.0" />
+      <PackageReference Include="MediatR" Version="12.4.1" />
       <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
       <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />

--- a/ErsatzTV.Core/Scheduling/BlockScheduling/BlockPlayoutBuilder.cs
+++ b/ErsatzTV.Core/Scheduling/BlockScheduling/BlockPlayoutBuilder.cs
@@ -265,9 +265,12 @@ public class BlockPlayoutBuilder(
                 playout,
                 blockItem,
                 historyKey),
-            PlaybackOrder.RandomRotation => new RandomizedRotatingMediaCollectionEnumerator(
+            PlaybackOrder.RandomRotation => BlockPlayoutEnumerator.RandomRotation(
                 collectionItems,
-                new CollectionEnumeratorState { Seed = new Random().Next(), Index = 0 }),
+                currentTime,
+                playout,
+                blockItem,
+                historyKey),
             _ => new RandomizedMediaCollectionEnumerator(
                 collectionItems,
                 new CollectionEnumeratorState { Seed = new Random().Next(), Index = 0 })

--- a/ErsatzTV.Core/Scheduling/BlockScheduling/BlockPlayoutBuilder.cs
+++ b/ErsatzTV.Core/Scheduling/BlockScheduling/BlockPlayoutBuilder.cs
@@ -43,7 +43,8 @@ public class BlockPlayoutBuilder(
             PlaybackOrder.Chronological,
             PlaybackOrder.SeasonEpisode,
             PlaybackOrder.Shuffle,
-            PlaybackOrder.Random
+            PlaybackOrder.Random,
+            PlaybackOrder.RandomRotation
         ];
 
         DateTimeOffset start = DateTimeOffset.Now;
@@ -264,6 +265,9 @@ public class BlockPlayoutBuilder(
                 playout,
                 blockItem,
                 historyKey),
+            PlaybackOrder.RandomRotation => new RandomizedRotatingMediaCollectionEnumerator(
+                collectionItems,
+                new CollectionEnumeratorState { Seed = new Random().Next(), Index = 0 }),
             _ => new RandomizedMediaCollectionEnumerator(
                 collectionItems,
                 new CollectionEnumeratorState { Seed = new Random().Next(), Index = 0 })

--- a/ErsatzTV.Core/Scheduling/BlockScheduling/BlockPlayoutEnumerator.cs
+++ b/ErsatzTV.Core/Scheduling/BlockScheduling/BlockPlayoutEnumerator.cs
@@ -156,7 +156,10 @@ public static class BlockPlayoutEnumerator
         var state = new CollectionEnumeratorState { Seed = playout.Seed + blockItem.BlockId, Index = 0 };
         foreach (PlayoutHistory h in maybeHistory)
         {
-            state.Index = h.Index + 1;
+            // Make sure to only increase the index by 1 since we can only
+            // guarantee the next one is a different show. h.Index comes from
+            // the previous play item which already increased by 1.
+            state.Index = h.Index;
         }
 
         return new RandomizedRotatingMediaCollectionEnumerator(collectionItems, state);

--- a/ErsatzTV.Core/Scheduling/RandomizedRotatingMediaCollectionEnumerator.cs
+++ b/ErsatzTV.Core/Scheduling/RandomizedRotatingMediaCollectionEnumerator.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using ErsatzTV.Core.Domain;
+﻿using ErsatzTV.Core.Domain;
 using ErsatzTV.Core.Extensions;
 using ErsatzTV.Core.Interfaces.Scheduling;
 
@@ -10,7 +9,7 @@ public class RandomizedRotatingMediaCollectionEnumerator : IMediaCollectionEnume
     private readonly Lazy<Option<TimeSpan>> _lazyMinimumDuration;
     private readonly IList<MediaItem> _mediaItems;
     private readonly Random _random;
-    private Dictionary<int, IList<int>> _groupMedia;
+    private readonly Dictionary<int, IList<int>> _groupMedia;
     private int _index;
 
     public RandomizedRotatingMediaCollectionEnumerator(IList<MediaItem> mediaItems, CollectionEnumeratorState state)
@@ -24,17 +23,22 @@ public class RandomizedRotatingMediaCollectionEnumerator : IMediaCollectionEnume
         _random = new Random(state.Seed);
 
         _groupMedia = new Dictionary<int, IList<int>>();
-        for (int i = 0; i < mediaItems.Count; i++) {
-            int id = mediaItems[i] switch {
+        for (int i = 0; i < mediaItems.Count; i++)
+        {
+            int id = mediaItems[i] switch
+            {
                 Episode e => e.Season.ShowId,
                 MusicVideo mv => mv.ArtistId,
                 _ => mediaItems[i].Id
             };
 
-            if (_groupMedia.TryGetValue(id, out IList<int> newList)) {
+            if (_groupMedia.TryGetValue(id, out IList<int> newList))
+            {
                 newList.Add(i);
-            } else {
-                _groupMedia.Add(id, new List<int>(){i});
+            }
+            else
+            {
+                _groupMedia.Add(id, new List<int> { i });
             }
         }
 

--- a/ErsatzTV.Core/Scheduling/RandomizedRotatingMediaCollectionEnumerator.cs
+++ b/ErsatzTV.Core/Scheduling/RandomizedRotatingMediaCollectionEnumerator.cs
@@ -11,6 +11,7 @@ public class RandomizedRotatingMediaCollectionEnumerator : IMediaCollectionEnume
     private readonly Random _random;
     private readonly Dictionary<int, IList<int>> _groupMedia;
     private int _index;
+    private int _groupNumber;
 
     public RandomizedRotatingMediaCollectionEnumerator(IList<MediaItem> mediaItems, CollectionEnumeratorState state)
     {
@@ -42,6 +43,8 @@ public class RandomizedRotatingMediaCollectionEnumerator : IMediaCollectionEnume
             }
         }
 
+        _groupNumber = 0;
+
         State = new CollectionEnumeratorState { Seed = state.Seed };
         // we want to move at least once so we start with a random item and not the first
         // because _index defaults to 0
@@ -65,11 +68,25 @@ public class RandomizedRotatingMediaCollectionEnumerator : IMediaCollectionEnume
         IList<int> groups = _groupMedia.Keys.ToList();
         int nextRandom = _random.Next();
 
-        // It is possible to get the same group (show/artist) as the previous scheduled item,
-        // but when the number of shows/artists is large, the chance is small.
         int groupNumber = nextRandom % groups.Count;
-        int itemNumber = nextRandom % _groupMedia[groups[groupNumber]].Count;
-        _index = _groupMedia[groups[groupNumber]][itemNumber];
+        if (_groupNumber == groupNumber)
+        {
+            if (groupNumber == groups.Count - 1)
+            {
+                _groupNumber = 0;
+            }
+            else
+            {
+                _groupNumber = groupNumber + 1;
+            }
+        }
+        else
+        {
+            _groupNumber = groupNumber;
+        }
+
+        int itemNumber = nextRandom % _groupMedia[groups[_groupNumber]].Count;
+        _index = _groupMedia[groups[_groupNumber]][itemNumber];
         State.Index++;
     }
 

--- a/ErsatzTV.Core/Scheduling/RandomizedRotatingMediaCollectionEnumerator.cs
+++ b/ErsatzTV.Core/Scheduling/RandomizedRotatingMediaCollectionEnumerator.cs
@@ -1,0 +1,75 @@
+﻿using System.Collections.Generic;
+using ErsatzTV.Core.Domain;
+using ErsatzTV.Core.Extensions;
+using ErsatzTV.Core.Interfaces.Scheduling;
+
+namespace ErsatzTV.Core.Scheduling;
+
+public class RandomizedRotatingMediaCollectionEnumerator : IMediaCollectionEnumerator
+{
+    private readonly Lazy<Option<TimeSpan>> _lazyMinimumDuration;
+    private readonly IList<MediaItem> _mediaItems;
+    private readonly Random _random;
+    private Dictionary<int, IList<int>> _groupMedia;
+    private int _index;
+
+    public RandomizedRotatingMediaCollectionEnumerator(IList<MediaItem> mediaItems, CollectionEnumeratorState state)
+    {
+        CurrentIncludeInProgramGuide = Option<bool>.None;
+
+        _mediaItems = mediaItems;
+        _lazyMinimumDuration =
+            new Lazy<Option<TimeSpan>>(
+                () => _mediaItems.Bind(i => i.GetNonZeroDuration()).OrderBy(identity).HeadOrNone());
+        _random = new Random(state.Seed);
+
+        _groupMedia = new Dictionary<int, IList<int>>();
+        for (int i = 0; i < mediaItems.Count; i++) {
+            int id = mediaItems[i] switch {
+                Episode e => e.Season.ShowId,
+                MusicVideo mv => mv.ArtistId,
+                _ => mediaItems[i].Id
+            };
+
+            if (_groupMedia.TryGetValue(id, out IList<int> newList)) {
+                newList.Add(i);
+            } else {
+                _groupMedia.Add(id, new List<int>(){i});
+            }
+        }
+
+        State = new CollectionEnumeratorState { Seed = state.Seed };
+        // we want to move at least once so we start with a random item and not the first
+        // because _index defaults to 0
+        while (State.Index <= state.Index)
+        {
+            MoveNext();
+        }
+    }
+
+    public void ResetState(CollectionEnumeratorState state) =>
+        // seed never changes here, no need to reset
+        State.Index = state.Index;
+
+    public CollectionEnumeratorState State { get; }
+
+    public Option<MediaItem> Current => _mediaItems.Any() ? _mediaItems[_index] : None;
+    public Option<bool> CurrentIncludeInProgramGuide { get; }
+
+    public void MoveNext()
+    {
+        IList<int> groups = _groupMedia.Keys.ToList();
+        int nextRandom = _random.Next();
+
+        // It is possible to get the same group (show/artist) as the previous scheduled item,
+        // but when the number of shows/artists is large, the chance is small.
+        int groupNumber = nextRandom % groups.Count;
+        int itemNumber = nextRandom % _groupMedia[groups[groupNumber]].Count;
+        _index = _groupMedia[groups[groupNumber]][itemNumber];
+        State.Index++;
+    }
+
+    public Option<TimeSpan> MinimumDuration => _lazyMinimumDuration.Value;
+
+    public int Count => _mediaItems.Count;
+}

--- a/ErsatzTV.FFmpeg.Tests/ErsatzTV.FFmpeg.Tests.csproj
+++ b/ErsatzTV.FFmpeg.Tests/ErsatzTV.FFmpeg.Tests.csproj
@@ -8,9 +8,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="FluentAssertions" Version="6.12.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
         <PackageReference Include="NSubstitute" Version="5.1.0" />
         <PackageReference Include="NUnit" Version="4.2.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />

--- a/ErsatzTV.Infrastructure.Tests/ErsatzTV.Infrastructure.Tests.csproj
+++ b/ErsatzTV.Infrastructure.Tests/ErsatzTV.Infrastructure.Tests.csproj
@@ -9,8 +9,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.12.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+        <PackageReference Include="FluentAssertions" Version="6.12.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
         <PackageReference Include="NSubstitute" Version="5.1.0" />
         <PackageReference Include="NUnit" Version="4.2.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />

--- a/ErsatzTV.Infrastructure/ErsatzTV.Infrastructure.csproj
+++ b/ErsatzTV.Infrastructure/ErsatzTV.Infrastructure.csproj
@@ -13,7 +13,7 @@
       <PackageReference Include="Blurhash.ImageSharp" Version="3.0.0" />
       <PackageReference Include="CliWrap" Version="3.6.6" />
       <PackageReference Include="Dapper" Version="2.1.35" />
-      <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.15.5" />
+      <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.15.6" />
       <PackageReference Include="Jint" Version="4.0.2" />
       <PackageReference Include="Lucene.Net" Version="4.8.0-beta00016" />
       <PackageReference Include="Lucene.Net.Analysis.Common" Version="4.8.0-beta00016" />

--- a/ErsatzTV.Scanner.Tests/ErsatzTV.Scanner.Tests.csproj
+++ b/ErsatzTV.Scanner.Tests/ErsatzTV.Scanner.Tests.csproj
@@ -9,9 +9,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="FluentAssertions" Version="6.12.1" />
         <PackageReference Include="LanguageExt.Core" Version="4.4.9" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
         <PackageReference Include="NSubstitute" Version="5.1.0" />
         <PackageReference Include="NUnit" Version="4.2.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />

--- a/ErsatzTV.Scanner/ErsatzTV.Scanner.csproj
+++ b/ErsatzTV.Scanner/ErsatzTV.Scanner.csproj
@@ -23,7 +23,7 @@
       <PackageReference Include="CliWrap" Version="3.6.6" />
       <PackageReference Include="Humanizer.Core" Version="2.14.1" />
       <PackageReference Include="LanguageExt.Core" Version="4.4.9" />
-      <PackageReference Include="MediatR" Version="12.4.0" />
+      <PackageReference Include="MediatR" Version="12.4.1" />
       <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />

--- a/ErsatzTV/ErsatzTV.csproj
+++ b/ErsatzTV/ErsatzTV.csproj
@@ -20,7 +20,7 @@
       <PackageReference Include="Bugsnag.AspNet.Core" Version="3.1.0" />
       <PackageReference Include="FluentValidation" Version="11.9.2" />
       <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
-      <PackageReference Include="Heron.MudCalendar" Version="2.0.1" />
+      <PackageReference Include="Heron.MudCalendar" Version="2.0.2" />
       <PackageReference Include="HtmlSanitizer" Version="8.1.870" />
       <PackageReference Include="LanguageExt.Core" Version="4.4.9" />
       <PackageReference Include="Markdig" Version="0.37.0" />
@@ -37,7 +37,7 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="MudBlazor" Version="7.7.0" />
+      <PackageReference Include="MudBlazor" Version="7.8.0" />
       <PackageReference Include="NaturalSort.Extension" Version="4.3.0" />
       <PackageReference Include="Refit.HttpClientFactory" Version="7.1.2" />
       <PackageReference Include="Serilog" Version="4.0.1" />

--- a/ErsatzTV/Pages/BlockEditor.razor
+++ b/ErsatzTV/Pages/BlockEditor.razor
@@ -230,6 +230,7 @@
                                     <MudSelectItem Value="PlaybackOrder.Chronological">Chronological</MudSelectItem>
                                     <MudSelectItem Value="PlaybackOrder.Shuffle">Shuffle</MudSelectItem>
                                     <MudSelectItem Value="PlaybackOrder.Random">Random</MudSelectItem>
+                                    <MudSelectItem Value="PlaybackOrder.RandomRotation">RandomRotation</MudSelectItem>
                                     @* <MudSelectItem Value="PlaybackOrder.ShuffleInOrder">Shuffle In Order</MudSelectItem> *@
                                     break;
                                 case ProgramScheduleItemCollectionType.TelevisionShow:

--- a/ErsatzTV/Pages/BlockEditor.razor
+++ b/ErsatzTV/Pages/BlockEditor.razor
@@ -230,7 +230,7 @@
                                     <MudSelectItem Value="PlaybackOrder.Chronological">Chronological</MudSelectItem>
                                     <MudSelectItem Value="PlaybackOrder.Shuffle">Shuffle</MudSelectItem>
                                     <MudSelectItem Value="PlaybackOrder.Random">Random</MudSelectItem>
-                                    <MudSelectItem Value="PlaybackOrder.RandomRotation">RandomRotation</MudSelectItem>
+                                    <MudSelectItem Value="PlaybackOrder.RandomRotation">Random Rotation</MudSelectItem>
                                     @* <MudSelectItem Value="PlaybackOrder.ShuffleInOrder">Shuffle In Order</MudSelectItem> *@
                                     break;
                                 case ProgramScheduleItemCollectionType.TelevisionShow:


### PR DESCRIPTION
This PR introduces a new mode RandomRotation that first randomly choose a group (show/artist), then choose a random item for the next schedule item. This works similar to the random schedule with "FillWithGroupMode", but is for the block scheduling. It provides a way to balance the random schedule between long running TV shows and short mini series.