### PR TITLE
[Filler] Add random count for filler preset

### DIFF
--- a/ErsatzTV.Core/Domain/Filler/FillerMode.cs
+++ b/ErsatzTV.Core/Domain/Filler/FillerMode.cs
@@ -5,5 +5,6 @@ public enum FillerMode
     None = 0,
     Duration = 1,
     Count = 2,
-    Pad = 3
+    Pad = 3,
+    RandomCount = 4
 }

--- a/ErsatzTV.Core/Scheduling/PlayoutModeSchedulerBase.cs
+++ b/ErsatzTV.Core/Scheduling/PlayoutModeSchedulerBase.cs
@@ -750,32 +750,17 @@ public abstract class PlayoutModeSchedulerBase<T> : IPlayoutModeScheduler<T> whe
         CancellationToken cancellationToken)
     {
         var result = new List<PlayoutItem>();
-
         Random rnd = new Random();
         // randomCount is from 0 to count.
         int randomCount = rnd.Next() % (count + 1);
 
-        for (var i = 0; i < randomCount; i++)
-        {
-            foreach (MediaItem mediaItem in enumerator.Current)
-            {
-                TimeSpan itemDuration = DurationForMediaItem(mediaItem);
-
-                var playoutItem = new PlayoutItem
-                {
-                    MediaItemId = mediaItem.Id,
-                    Start = new DateTime(2020, 2, 1, 0, 0, 0, DateTimeKind.Utc),
-                    Finish = new DateTime(2020, 2, 1, 0, 0, 0, DateTimeKind.Utc) + itemDuration,
-                    InPoint = TimeSpan.Zero,
-                    OutPoint = itemDuration,
-                    GuideGroup = playoutBuilderState.NextGuideGroup,
-                    FillerKind = fillerKind,
-                    DisableWatermarks = !allowWatermarks
-                };
-
-                result.Add(playoutItem);
-                enumerator.MoveNext();
-            }
+        if (randomCount != 0) {
+            result = AddCountFiller(playoutBuilderState,
+                                    enumerator,
+                                    randomCount,
+                                    fillerKind,
+                                    allowWatermarks,
+                                    cancellationToken);
         }
 
         return result;

--- a/ErsatzTV.Core/Scheduling/PlayoutModeSchedulerBase.cs
+++ b/ErsatzTV.Core/Scheduling/PlayoutModeSchedulerBase.cs
@@ -752,7 +752,8 @@ public abstract class PlayoutModeSchedulerBase<T> : IPlayoutModeScheduler<T> whe
         var result = new List<PlayoutItem>();
 
         Random rnd = new Random();
-        int randomCount = rnd.Next() % count + 1;
+        // randomCount is from 0 to count.
+        int randomCount = rnd.Next() % (count + 1);
 
         for (var i = 0; i < randomCount; i++)
         {

--- a/ErsatzTV/Pages/FillerPresetEditor.razor
+++ b/ErsatzTV/Pages/FillerPresetEditor.razor
@@ -35,9 +35,10 @@
                             <MudSelectItem Value="@(FillerMode.Duration)">Duration</MudSelectItem>
                             <MudSelectItem Value="@(FillerMode.Count)">Count</MudSelectItem>
                             <MudSelectItem Value="@(FillerMode.Pad)">Pad</MudSelectItem>
+                            <MudSelectItem Value="@(FillerMode.RandomCount)">RandomCount</MudSelectItem>
                         </MudSelect>
                         <MudTimePicker Class="mt-3" Label="Filler Duration" @bind-Time="@_model.Duration" For="@(() => _model.Duration)" Disabled="@(_model.FillerMode != FillerMode.Duration)"/>
-                        <MudTextField Class="mt-3" Label="Filler Count" @bind-Value="@_model.Count" For="@(() => _model.Count)" Disabled="@(_model.FillerMode != FillerMode.Count)"/>
+                        <MudTextField Class="mt-3" Label="Filler Count" @bind-Value="@_model.Count" For="@(() => _model.Count)" Disabled="@((_model.FillerMode != FillerMode.Count) && (_model.FillerMode != FillerMode.RandomCount))"/>
                         <MudSelect Class="mt-3" Label="Filler Pad To Nearest Minute" @bind-Value="_model.PadToNearestMinute" For="@(() => _model.PadToNearestMinute)" Disabled="@(_model.FillerMode != FillerMode.Pad)">
                             <MudSelectItem T="int?" Value="5">5 (:00, :05, :10, :15, :20, etc)</MudSelectItem>
                             <MudSelectItem T="int?" Value="10">10 (:00, :10, :20, :30, :40, :50)</MudSelectItem>
@@ -187,6 +188,7 @@
                     _model.FillerMode = fillerPreset.FillerMode;
                     _model.Duration = fillerPreset.Duration;
                     _model.Count = fillerPreset.Count;
+                    //_model.RandomCount = fillerPreset.RandomCount;
                     _model.PadToNearestMinute = fillerPreset.PadToNearestMinute;
                     _model.AllowWatermarks = fillerPreset.AllowWatermarks;
                     _model.CollectionType = fillerPreset.CollectionType;

--- a/ErsatzTV/Pages/FillerPresetEditor.razor
+++ b/ErsatzTV/Pages/FillerPresetEditor.razor
@@ -35,7 +35,7 @@
                             <MudSelectItem Value="@(FillerMode.Duration)">Duration</MudSelectItem>
                             <MudSelectItem Value="@(FillerMode.Count)">Count</MudSelectItem>
                             <MudSelectItem Value="@(FillerMode.Pad)">Pad</MudSelectItem>
-                            <MudSelectItem Value="@(FillerMode.RandomCount)">RandomCount</MudSelectItem>
+                            <MudSelectItem Value="@(FillerMode.RandomCount)">Random Count</MudSelectItem>
                         </MudSelect>
                         <MudTimePicker Class="mt-3" Label="Filler Duration" @bind-Time="@_model.Duration" For="@(() => _model.Duration)" Disabled="@(_model.FillerMode != FillerMode.Duration)"/>
                         <MudTextField Class="mt-3" Label="Filler Count" @bind-Value="@_model.Count" For="@(() => _model.Count)" Disabled="@((_model.FillerMode != FillerMode.Count) && (_model.FillerMode != FillerMode.RandomCount))"/>
@@ -188,7 +188,6 @@
                     _model.FillerMode = fillerPreset.FillerMode;
                     _model.Duration = fillerPreset.Duration;
                     _model.Count = fillerPreset.Count;
-                    //_model.RandomCount = fillerPreset.RandomCount;
                     _model.PadToNearestMinute = fillerPreset.PadToNearestMinute;
                     _model.AllowWatermarks = fillerPreset.AllowWatermarks;
                     _model.CollectionType = fillerPreset.CollectionType;

--- a/ErsatzTV/ViewModels/FillerPresetEditViewModel.cs
+++ b/ErsatzTV/ViewModels/FillerPresetEditViewModel.cs
@@ -47,7 +47,7 @@ public class FillerPresetEditViewModel
 
     public int? Count
     {
-        get => FillerMode == FillerMode.Count ? _count : null;
+        get => ((FillerMode == FillerMode.Count) || (FillerMode == FillerMode.RandomCount)) ? _count : null;
         set => _count = value;
     }
 


### PR DESCRIPTION
Add randomized count support for filler preset. The filler Count is the maximum number of fillers added. The number of fillers is randomly generated between 0 and the filler Count (including the Count number).