### PR TITLE
[scheduling] add Latest mode for block scheduling

### DIFF
--- a/ErsatzTV.Application/ProgramSchedules/Commands/ProgramScheduleItemCommandBase.cs
+++ b/ErsatzTV.Application/ProgramSchedules/Commands/ProgramScheduleItemCommandBase.cs
@@ -58,6 +58,7 @@ public abstract class ProgramScheduleItemCommandBase
                 case PlaybackOrder.MultiEpisodeShuffle:
                 case PlaybackOrder.SeasonEpisode:
                 case PlaybackOrder.RandomRotation:
+                case PlaybackOrder.Latest:
                     return BaseError.New($"Invalid playback order for multi collection: '{item.PlaybackOrder}'");
                 case PlaybackOrder.Shuffle:
                 case PlaybackOrder.ShuffleInOrder:

--- a/ErsatzTV.Core/Domain/PlaybackOrder.cs
+++ b/ErsatzTV.Core/Domain/PlaybackOrder.cs
@@ -8,5 +8,6 @@ public enum PlaybackOrder
     ShuffleInOrder = 4,
     MultiEpisodeShuffle = 5,
     SeasonEpisode = 6,
-    RandomRotation = 7
+    RandomRotation = 7,
+    Latest = 8
 }

--- a/ErsatzTV.Core/Scheduling/BlockScheduling/BlockPlayoutBuilder.cs
+++ b/ErsatzTV.Core/Scheduling/BlockScheduling/BlockPlayoutBuilder.cs
@@ -44,11 +44,8 @@ public class BlockPlayoutBuilder(
             PlaybackOrder.SeasonEpisode,
             PlaybackOrder.Shuffle,
             PlaybackOrder.Random,
-<<<<<<< HEAD
-            PlaybackOrder.RandomRotation
-=======
+            PlaybackOrder.RandomRotation,
             PlaybackOrder.Latest,
->>>>>>> 70e57faf (init)
         ];
 
         DateTimeOffset start = DateTimeOffset.Now;

--- a/ErsatzTV.Core/Scheduling/BlockScheduling/BlockPlayoutBuilder.cs
+++ b/ErsatzTV.Core/Scheduling/BlockScheduling/BlockPlayoutBuilder.cs
@@ -44,7 +44,11 @@ public class BlockPlayoutBuilder(
             PlaybackOrder.SeasonEpisode,
             PlaybackOrder.Shuffle,
             PlaybackOrder.Random,
+<<<<<<< HEAD
             PlaybackOrder.RandomRotation
+=======
+            PlaybackOrder.Latest,
+>>>>>>> 70e57faf (init)
         ];
 
         DateTimeOffset start = DateTimeOffset.Now;
@@ -266,6 +270,12 @@ public class BlockPlayoutBuilder(
                 blockItem,
                 historyKey),
             PlaybackOrder.RandomRotation => BlockPlayoutEnumerator.RandomRotation(
+                collectionItems,
+                currentTime,
+                playout,
+                blockItem,
+                historyKey),
+            PlaybackOrder.Latest => BlockPlayoutEnumerator.Latest(
                 collectionItems,
                 currentTime,
                 playout,

--- a/ErsatzTV.Core/Scheduling/BlockScheduling/BlockPlayoutEnumerator.cs
+++ b/ErsatzTV.Core/Scheduling/BlockScheduling/BlockPlayoutEnumerator.cs
@@ -180,21 +180,11 @@ public static class BlockPlayoutEnumerator
             .OrderByDescending(h => h.When)
             .HeadOrNone();    
         var state = new CollectionEnumeratorState { Seed = 0, Index = 0 };
+        foreach (PlayoutHistory h in maybeHistory)
+        {
+            state.Index = h.Index + 1;
+        }
 
-        var enumerator = new LatestMediaCollectionEnumerator(collectionItems, state);
-
-        // seek to the appropriate place in the collection enumerator
-        //foreach (PlayoutHistory h in maybeHistory)
-        //{
-            //logger.LogDebug("History is applicable: {When}: {History}", h.When, h.Details);
-
-            //HistoryDetails.MoveToNextItem(
-            //    collectionItems,
-            //    h.Details,
-            //    enumerator,
-            //    blockItem.PlaybackOrder);
-        //}
-
-        return enumerator;
+        return new LatestMediaCollectionEnumerator(collectionItems, state);
     }
 }

--- a/ErsatzTV.Core/Scheduling/BlockScheduling/BlockPlayoutEnumerator.cs
+++ b/ErsatzTV.Core/Scheduling/BlockScheduling/BlockPlayoutEnumerator.cs
@@ -164,4 +164,37 @@ public static class BlockPlayoutEnumerator
 
         return new RandomizedRotatingMediaCollectionEnumerator(collectionItems, state);
     }
+
+    public static IMediaCollectionEnumerator Latest(
+        List<MediaItem> collectionItems,
+        DateTimeOffset currentTime,
+        Playout playout,
+        BlockItem blockItem,
+        string historyKey)
+    {
+        DateTime historyTime = currentTime.UtcDateTime;
+        Option<PlayoutHistory> maybeHistory = playout.PlayoutHistory
+            .Filter(h => h.BlockId == blockItem.BlockId)
+            .Filter(h => h.Key == historyKey)
+            .Filter(h => h.When < historyTime)
+            .OrderByDescending(h => h.When)
+            .HeadOrNone();    
+        var state = new CollectionEnumeratorState { Seed = 0, Index = 0 };
+
+        var enumerator = new LatestMediaCollectionEnumerator(collectionItems, state);
+
+        // seek to the appropriate place in the collection enumerator
+        //foreach (PlayoutHistory h in maybeHistory)
+        //{
+            //logger.LogDebug("History is applicable: {When}: {History}", h.When, h.Details);
+
+            //HistoryDetails.MoveToNextItem(
+            //    collectionItems,
+            //    h.Details,
+            //    enumerator,
+            //    blockItem.PlaybackOrder);
+        //}
+
+        return enumerator;
+    }
 }

--- a/ErsatzTV.Core/Scheduling/LatestMediaCollectionEnumerator.cs
+++ b/ErsatzTV.Core/Scheduling/LatestMediaCollectionEnumerator.cs
@@ -1,0 +1,52 @@
+using ErsatzTV.Core.Domain;
+using ErsatzTV.Core.Extensions;
+using ErsatzTV.Core.Interfaces.Scheduling;
+
+namespace ErsatzTV.Core.Scheduling;
+
+public sealed class LatestMediaCollectionEnumerator : IMediaCollectionEnumerator
+{
+    private readonly Lazy<Option<TimeSpan>> _lazyMinimumDuration;
+    private readonly IList<MediaItem> _sortedMediaItems;
+
+    public LatestMediaCollectionEnumerator(
+        IEnumerable<MediaItem> mediaItems,
+        CollectionEnumeratorState state)
+    {
+        CurrentIncludeInProgramGuide = Option<bool>.None;
+
+        _sortedMediaItems = mediaItems.OrderBy(identity, new ChronologicalMediaComparer()).ToList();
+        _lazyMinimumDuration = new Lazy<Option<TimeSpan>>(
+            () => _sortedMediaItems.Bind(i => i.GetNonZeroDuration()).OrderBy(identity).HeadOrNone());
+
+        State = new CollectionEnumeratorState { Seed = state.Seed };
+
+        if (state.Index >= _sortedMediaItems.Count)
+        {
+            state.Index = 0;
+            state.Seed = 0;
+        }
+
+        State.Index = _sortedMediaItems.Count - 1;
+
+        //while (State.Index < state.Index)
+        //{
+        //    MoveNext();
+        //}
+    }
+
+    public void ResetState(CollectionEnumeratorState state) =>
+        // seed doesn't matter in chronological
+        State.Index = state.Index;
+
+    public CollectionEnumeratorState State { get; }
+
+    public Option<MediaItem> Current => _sortedMediaItems.Any() ? _sortedMediaItems[State.Index] : None;
+    public Option<bool> CurrentIncludeInProgramGuide { get; }
+
+    public void MoveNext() => State.Index = _sortedMediaItems.Count - 1;
+
+    public Option<TimeSpan> MinimumDuration => _lazyMinimumDuration.Value;
+
+    public int Count => _sortedMediaItems.Count;
+}

--- a/ErsatzTV.Core/Scheduling/LatestMediaCollectionEnumerator.cs
+++ b/ErsatzTV.Core/Scheduling/LatestMediaCollectionEnumerator.cs
@@ -24,14 +24,6 @@ public sealed class LatestMediaCollectionEnumerator : IMediaCollectionEnumerator
         // Here we simply use State.Index to track how many times we repeated.
         State = new CollectionEnumeratorState { Seed = state.Seed };
 
-        //if (state.Index >= _sortedMediaItems.Count)
-        //{
-        //    state.Index = 0;
-        //    state.Seed = 0;
-        //}
-
-        //State.Index = _sortedMediaItems.Count - 1;
-
         _latest = _sortedMediaItems.Count - 1;
 
         while (State.Index < state.Index)

--- a/ErsatzTV.Core/Scheduling/LatestMediaCollectionEnumerator.cs
+++ b/ErsatzTV.Core/Scheduling/LatestMediaCollectionEnumerator.cs
@@ -21,7 +21,7 @@ public sealed class LatestMediaCollectionEnumerator : IMediaCollectionEnumerator
             () => _sortedMediaItems.Bind(i => i.GetNonZeroDuration()).OrderBy(identity).HeadOrNone());
 
         // State isn't needed in latest play mode.
-        // Here we simply use State.Index to track how many times we repeated.
+        // Here we simply use State.Index to track how many times we were scheduled.
         State = new CollectionEnumeratorState { Seed = state.Seed };
 
         _latest = _sortedMediaItems.Count - 1;

--- a/ErsatzTV/Pages/BlockEditor.razor
+++ b/ErsatzTV/Pages/BlockEditor.razor
@@ -238,6 +238,7 @@
                                     <MudSelectItem Value="PlaybackOrder.Chronological">Chronological</MudSelectItem>
                                     <MudSelectItem Value="PlaybackOrder.Shuffle">Shuffle</MudSelectItem>
                                     <MudSelectItem Value="PlaybackOrder.Random">Random</MudSelectItem>
+                                    <MudSelectItem Value="PlaybackOrder.Latest">Latest</MudSelectItem>
                                     @* <MudSelectItem Value="PlaybackOrder.MultiEpisodeShuffle">Multi-Episode Shuffle</MudSelectItem> *@
                                     break;
                                 case ProgramScheduleItemCollectionType.TelevisionSeason:


### PR DESCRIPTION
Adding Latest play mode for block scheduling for ongoing shows, such as News, Sports, Daily/Nightly shows, and shows like SNL. This mode always plays the latest episode of such shows that is expected to be scheduled after it was aired and became available (after etv media rescan).