### PR TITLE
Introducing ErsatzTV Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **ErsatzTV** is beta software for configuring and streaming custom live channels using your media library. The software may be unstable and is under active development.
 
-Documentation is available at [ersatztv.org](https://ersatztv.org/).
+Documentation is available at [ersatztv.org](https://ersatztv.org/). You can also [Ask ErsatzTV Guru](https://gurubase.io/g/ersatztv), it is an ErsatzTV-focused AI to answer your questions.
 
 Want to join the community or have a question? Join us at the [ErsatzTV Community](https://discuss.ersatztv.org/) or on [Discord](https://discord.gg/hHaJm3yGy6).
 


### PR DESCRIPTION
Hello ErsatzTV team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [ErsatzTV Guru](https://gurubase.io/g/ersatztv) to Gurubase. ErsatzTV Guru uses the data from this repo and data from the [docs](https://ersatztv.org/docs/intro/) to answer questions by leveraging the LLM.

In this PR, I showcased the "ErsatzTV Guru" on the README, which highlights that ErsatzTV now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable ErsatzTV Guru in Gurubase, just let me know that's totally fine.