### PR TITLE
add `rewind_on_reset` option `wait_until` yaml playout instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Added
 - Add `Reset All Playouts` button to top of playouts page
+- Add `rewind_on_reset` option to `wait_until` YAML playout instruction to allow
+  - This option allows YAML playouts to start in the past
 
 ### Changed
 - **BREAKING CHANGE**: Change channel identifiers used in XMLTV to work around bad behavior in Plex

--- a/ErsatzTV.Core/Scheduling/YamlScheduling/Handlers/IYamlPlayoutHandler.cs
+++ b/ErsatzTV.Core/Scheduling/YamlScheduling/Handlers/IYamlPlayoutHandler.cs
@@ -10,6 +10,7 @@ public interface IYamlPlayoutHandler
     Task<bool> Handle(
         YamlPlayoutContext context,
         YamlPlayoutInstruction instruction,
+        PlayoutBuildMode mode,
         ILogger<YamlPlayoutBuilder> logger,
         CancellationToken cancellationToken);
 }

--- a/ErsatzTV.Core/Scheduling/YamlScheduling/Handlers/YamlPlayoutAllHandler.cs
+++ b/ErsatzTV.Core/Scheduling/YamlScheduling/Handlers/YamlPlayoutAllHandler.cs
@@ -11,6 +11,7 @@ public class YamlPlayoutAllHandler(EnumeratorCache enumeratorCache) : YamlPlayou
     public override async Task<bool> Handle(
         YamlPlayoutContext context,
         YamlPlayoutInstruction instruction,
+        PlayoutBuildMode mode,
         ILogger<YamlPlayoutBuilder> logger,
         CancellationToken cancellationToken)
     {

--- a/ErsatzTV.Core/Scheduling/YamlScheduling/Handlers/YamlPlayoutContentHandler.cs
+++ b/ErsatzTV.Core/Scheduling/YamlScheduling/Handlers/YamlPlayoutContentHandler.cs
@@ -15,6 +15,7 @@ public abstract class YamlPlayoutContentHandler(EnumeratorCache enumeratorCache)
     public abstract Task<bool> Handle(
         YamlPlayoutContext context,
         YamlPlayoutInstruction instruction,
+        PlayoutBuildMode mode,
         ILogger<YamlPlayoutBuilder> logger,
         CancellationToken cancellationToken);
 

--- a/ErsatzTV.Core/Scheduling/YamlScheduling/Handlers/YamlPlayoutCountHandler.cs
+++ b/ErsatzTV.Core/Scheduling/YamlScheduling/Handlers/YamlPlayoutCountHandler.cs
@@ -11,6 +11,7 @@ public class YamlPlayoutCountHandler(EnumeratorCache enumeratorCache) : YamlPlay
     public override async Task<bool> Handle(
         YamlPlayoutContext context,
         YamlPlayoutInstruction instruction,
+        PlayoutBuildMode mode,
         ILogger<YamlPlayoutBuilder> logger,
         CancellationToken cancellationToken)
     {

--- a/ErsatzTV.Core/Scheduling/YamlScheduling/Handlers/YamlPlayoutDurationHandler.cs
+++ b/ErsatzTV.Core/Scheduling/YamlScheduling/Handlers/YamlPlayoutDurationHandler.cs
@@ -13,6 +13,7 @@ public class YamlPlayoutDurationHandler(EnumeratorCache enumeratorCache) : YamlP
     public override async Task<bool> Handle(
         YamlPlayoutContext context,
         YamlPlayoutInstruction instruction,
+        PlayoutBuildMode mode,
         ILogger<YamlPlayoutBuilder> logger,
         CancellationToken cancellationToken)
     {

--- a/ErsatzTV.Core/Scheduling/YamlScheduling/Handlers/YamlPlayoutEpgGroupHandler.cs
+++ b/ErsatzTV.Core/Scheduling/YamlScheduling/Handlers/YamlPlayoutEpgGroupHandler.cs
@@ -10,6 +10,7 @@ public class YamlPlayoutEpgGroupHandler : IYamlPlayoutHandler
     public Task<bool> Handle(
         YamlPlayoutContext context,
         YamlPlayoutInstruction instruction,
+        PlayoutBuildMode mode,
         ILogger<YamlPlayoutBuilder> logger,
         CancellationToken cancellationToken)
     {

--- a/ErsatzTV.Core/Scheduling/YamlScheduling/Handlers/YamlPlayoutPadToNextHandler.cs
+++ b/ErsatzTV.Core/Scheduling/YamlScheduling/Handlers/YamlPlayoutPadToNextHandler.cs
@@ -9,6 +9,7 @@ public class YamlPlayoutPadToNextHandler(EnumeratorCache enumeratorCache) : Yaml
     public override async Task<bool> Handle(
         YamlPlayoutContext context,
         YamlPlayoutInstruction instruction,
+        PlayoutBuildMode mode,
         ILogger<YamlPlayoutBuilder> logger,
         CancellationToken cancellationToken)
     {

--- a/ErsatzTV.Core/Scheduling/YamlScheduling/Handlers/YamlPlayoutPadUntilHandler.cs
+++ b/ErsatzTV.Core/Scheduling/YamlScheduling/Handlers/YamlPlayoutPadUntilHandler.cs
@@ -9,6 +9,7 @@ public class YamlPlayoutPadUntilHandler(EnumeratorCache enumeratorCache) : YamlP
     public override async Task<bool> Handle(
         YamlPlayoutContext context,
         YamlPlayoutInstruction instruction,
+        PlayoutBuildMode mode,
         ILogger<YamlPlayoutBuilder> logger,
         CancellationToken cancellationToken)
     {

--- a/ErsatzTV.Core/Scheduling/YamlScheduling/Handlers/YamlPlayoutRepeatHandler.cs
+++ b/ErsatzTV.Core/Scheduling/YamlScheduling/Handlers/YamlPlayoutRepeatHandler.cs
@@ -12,6 +12,7 @@ public class YamlPlayoutRepeatHandler : IYamlPlayoutHandler
     public Task<bool> Handle(
         YamlPlayoutContext context,
         YamlPlayoutInstruction instruction,
+        PlayoutBuildMode mode,
         ILogger<YamlPlayoutBuilder> logger,
         CancellationToken cancellationToken)
     {

--- a/ErsatzTV.Core/Scheduling/YamlScheduling/Handlers/YamlPlayoutShuffleSequenceHandler.cs
+++ b/ErsatzTV.Core/Scheduling/YamlScheduling/Handlers/YamlPlayoutShuffleSequenceHandler.cs
@@ -10,6 +10,7 @@ public class YamlPlayoutShuffleSequenceHandler : IYamlPlayoutHandler
     public Task<bool> Handle(
         YamlPlayoutContext context,
         YamlPlayoutInstruction instruction,
+        PlayoutBuildMode mode,
         ILogger<YamlPlayoutBuilder> logger,
         CancellationToken cancellationToken)
     {

--- a/ErsatzTV.Core/Scheduling/YamlScheduling/Handlers/YamlPlayoutSkipItemsHandler.cs
+++ b/ErsatzTV.Core/Scheduling/YamlScheduling/Handlers/YamlPlayoutSkipItemsHandler.cs
@@ -11,6 +11,7 @@ public class YamlPlayoutSkipItemsHandler(EnumeratorCache enumeratorCache) : IYam
     public async Task<bool> Handle(
         YamlPlayoutContext context,
         YamlPlayoutInstruction instruction,
+        PlayoutBuildMode mode,
         ILogger<YamlPlayoutBuilder> logger,
         CancellationToken cancellationToken)
     {

--- a/ErsatzTV.Core/Scheduling/YamlScheduling/Handlers/YamlPlayoutSkipToItemHandler.cs
+++ b/ErsatzTV.Core/Scheduling/YamlScheduling/Handlers/YamlPlayoutSkipToItemHandler.cs
@@ -12,6 +12,7 @@ public class YamlPlayoutSkipToItemHandler(EnumeratorCache enumeratorCache) : IYa
     public async Task<bool> Handle(
         YamlPlayoutContext context,
         YamlPlayoutInstruction instruction,
+        PlayoutBuildMode mode,
         ILogger<YamlPlayoutBuilder> logger,
         CancellationToken cancellationToken)
     {

--- a/ErsatzTV.Core/Scheduling/YamlScheduling/Handlers/YamlPlayoutWaitUntilHandler.cs
+++ b/ErsatzTV.Core/Scheduling/YamlScheduling/Handlers/YamlPlayoutWaitUntilHandler.cs
@@ -10,6 +10,7 @@ public class YamlPlayoutWaitUntilHandler : IYamlPlayoutHandler
     public Task<bool> Handle(
         YamlPlayoutContext context,
         YamlPlayoutInstruction instruction,
+        PlayoutBuildMode mode,
         ILogger<YamlPlayoutBuilder> logger,
         CancellationToken cancellationToken)
     {
@@ -31,6 +32,11 @@ public class YamlPlayoutWaitUntilHandler : IYamlPlayoutHandler
                 {
                     // this is wrong when offset changes
                     dayOnly = dayOnly.AddDays(1);
+                    currentTime = new DateTimeOffset(dayOnly, result, currentTime.Offset);
+                }
+                else if (waitUntil.RewindOnReset && mode == PlayoutBuildMode.Reset)
+                {
+                    // maybe wrong when offset changes?
                     currentTime = new DateTimeOffset(dayOnly, result, currentTime.Offset);
                 }
             }

--- a/ErsatzTV.Core/Scheduling/YamlScheduling/Models/YamlPlayoutWaitUntilInstruction.cs
+++ b/ErsatzTV.Core/Scheduling/YamlScheduling/Models/YamlPlayoutWaitUntilInstruction.cs
@@ -6,5 +6,9 @@ public class YamlPlayoutWaitUntilInstruction : YamlPlayoutInstruction
 {
     [YamlMember(Alias = "wait_until", ApplyNamingConventions = false)]
     public string WaitUntil { get; set; }
+
     public bool Tomorrow { get; set; }
+
+    [YamlMember(Alias = "rewind_on_reset", ApplyNamingConventions = false)]
+    public bool RewindOnReset { get; set; }
 }

--- a/ErsatzTV.Core/Scheduling/YamlScheduling/YamlPlayoutBuilder.cs
+++ b/ErsatzTV.Core/Scheduling/YamlScheduling/YamlPlayoutBuilder.cs
@@ -121,7 +121,7 @@ public class YamlPlayoutBuilder(
                     }
                     else
                     {
-                        await handler.Handle(context, instruction, logger, cancellationToken);
+                        await handler.Handle(context, instruction, mode, logger, cancellationToken);
                     }
                 }
             }
@@ -145,7 +145,7 @@ public class YamlPlayoutBuilder(
 
             foreach (IYamlPlayoutHandler handler in maybeHandler)
             {
-                if (!await handler.Handle(context, instruction, logger, cancellationToken))
+                if (!await handler.Handle(context, instruction, mode, logger, cancellationToken))
                 {
                     logger.LogInformation("YAML playout instruction handler failed");
                 }


### PR DESCRIPTION
As an example, this block will force the playout to always start at 8:00 AM today (not tomorrow), even if it is already past 8:00 AM today.

```yaml
reset:
  - wait_until: '8:00am'
    tomorrow: false
    rewind_on_reset: true
```