### PR TITLE
stop building hwaccel-specific images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,14 +31,6 @@ jobs:
             path: ''
             suffix: ''
             qemu: false
-          - name: nvidia
-            path: 'nvidia/'
-            suffix: '-nvidia'
-            qemu: false
-          - name: vaapi
-            path: 'vaapi/'
-            suffix: '-vaapi'
-            qemu: false
           - name: arm32v7
             path: 'arm32v7/'
             suffix: '-arm'
@@ -82,12 +74,12 @@ jobs:
           file: ./docker/${{ matrix.path }}Dockerfile
           push: true
           build-args: |
-            INFO_VERSION=${{ inputs.info_version }}-docker${{ matrix.suffix }}
+            INFO_VERSION=${{ inputs.info_version }}-docker
           tags: |
-            jasongdove/ersatztv:${{ inputs.base_version }}${{ matrix.suffix }}
-            jasongdove/ersatztv:${{ inputs.tag_version }}${{ matrix.suffix }}
-            ghcr.io/ersatztv/ersatztv:${{ inputs.base_version }}${{ matrix.suffix }}
-            ghcr.io/ersatztv/ersatztv:${{ inputs.tag_version }}${{ matrix.suffix }}
+            jasongdove/ersatztv:${{ inputs.base_version }}
+            jasongdove/ersatztv:${{ inputs.tag_version }}
+            ghcr.io/ersatztv/ersatztv:${{ inputs.base_version }}
+            ghcr.io/ersatztv/ersatztv:${{ inputs.tag_version }}
         if: ${{ matrix.name != 'arm64' && matrix.name != 'arm32v7' }}
 
       - name: Build and push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Fixed
+- Fix QSV acceleration in docker with older Intel devices
 
 ## [25.2.0] - 2025-06-24
 ### Added


### PR DESCRIPTION
Also fixes https://github.com/ErsatzTV/ErsatzTV/issues/2069 by incorporating updated base image from https://github.com/ErsatzTV/ErsatzTV-ffmpeg/pull/23