### PR TITLE
fix video stream selection for remote streams

### DIFF
--- a/ErsatzTV.Application/Streaming/Queries/GetPlayoutItemProcessByChannelNumberHandler.cs
+++ b/ErsatzTV.Application/Streaming/Queries/GetPlayoutItemProcessByChannelNumberHandler.cs
@@ -295,6 +295,16 @@ public class GetPlayoutItemProcessByChannelNumberHandler : FFmpegProcessHandler<
                 audioPath = string.Empty;
             }
 
+            bool hlsRealtime = request.HlsRealtime;
+            if (playoutItemWithPath.PlayoutItem.MediaItem is RemoteStream remoteStream)
+            {
+                // duration implies live input which we cannot burst
+                if (remoteStream.Duration.HasValue)
+                {
+                    hlsRealtime = true;
+                }
+            }
+
             bool saveReports = await dbContext.ConfigElements
                 .GetValue<bool>(ConfigElementKey.FFmpegSaveReports)
                 .Map(result => result.IfNone(false));
@@ -329,7 +339,7 @@ public class GetPlayoutItemProcessByChannelNumberHandler : FFmpegProcessHandler<
                 channel.FFmpegProfile.VaapiDriver,
                 channel.FFmpegProfile.VaapiDevice,
                 Optional(channel.FFmpegProfile.QsvExtraHardwareFrames),
-                request.HlsRealtime,
+                hlsRealtime,
                 playoutItemWithPath.PlayoutItem.FillerKind,
                 inPoint,
                 outPoint,

--- a/ErsatzTV.Application/Troubleshooting/Commands/PrepareTroubleshootingPlaybackHandler.cs
+++ b/ErsatzTV.Application/Troubleshooting/Commands/PrepareTroubleshootingPlaybackHandler.cs
@@ -93,6 +93,16 @@ public class PrepareTroubleshootingPlaybackHandler(
             duration = TimeSpan.FromSeconds(30);
         }
 
+        var hlsRealtime = false;
+        if (mediaItem is RemoteStream remoteStream)
+        {
+            // duration implies live input which we cannot burst
+            if (remoteStream.Duration.HasValue)
+            {
+                hlsRealtime = true;
+            }
+        }
+
         Command process = await ffmpegProcessService.ForPlayoutItem(
             ffmpegPath,
             ffprobePath,
@@ -122,7 +132,7 @@ public class PrepareTroubleshootingPlaybackHandler(
             ffmpegProfile.VaapiDriver,
             ffmpegProfile.VaapiDevice,
             Option<int>.None,
-            false,
+            hlsRealtime,
             FillerKind.None,
             TimeSpan.Zero,
             duration,

--- a/ErsatzTV.FFmpeg/OutputFormat/OutputFormatHls.cs
+++ b/ErsatzTV.FFmpeg/OutputFormat/OutputFormatHls.cs
@@ -58,14 +58,6 @@ public class OutputFormatHls : IPipelineStep
                 _segmentTemplate
             ];
 
-            if (_isTroubleshooting)
-            {
-                result.AddRange(
-                [
-                    "-hls_playlist_type", "vod"
-                ]);
-            }
-
             string pdt = _isTroubleshooting ? string.Empty : "program_date_time+omit_endlist+";
 
             if (_isFirstTranscode)


### PR DESCRIPTION
helps with #2174 

- select and use video stream with highest bitrate instead of first video stream (sometimes lowest bitrate)
- limit remote streams to realtime when duration is specified, otherwise ffmpeg will try to read segments that don't yet exist