### PR TITLE
Display hostname & build configuration when build config is not "release"

### DIFF
--- a/ErsatzTV/Pages/_Host.cshtml
+++ b/ErsatzTV/Pages/_Host.cshtml
@@ -12,7 +12,7 @@
 <head>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <title>ErsatzTV</title>
+    <title>@if (Assembly.GetEntryAssembly().GetCustomAttribute<AssemblyConfigurationAttribute>()?.Configuration?.ToLower() != "release") { @(System.Environment.MachineName + " ") }ErsatzTV</title>
     <base href="~/"/>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet"/>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.2/css/all.min.css" rel="stylesheet">

--- a/ErsatzTV/Shared/MainLayout.razor
+++ b/ErsatzTV/Shared/MainLayout.razor
@@ -83,6 +83,10 @@
         <div style="align-items: center; display: flex;" class="d-none d-md-flex">
             @if (SystemStartup.IsDatabaseReady && SystemStartup.IsSearchIndexReady)
             {
+                @if (BuildConfiguration != "release")
+                {
+                    <MudText Color="Color.Warning" Class="mx-4">@System.Environment.MachineName</MudText>
+                }
                 <MudLink Color="Color.Info" Href="iptv/channels.m3u" Target="_blank" Underline="Underline.None">M3U</MudLink>
                 <MudLink Color="Color.Info" Href="iptv/xmltv.xml" Target="_blank" Class="mx-4" Underline="Underline.None">XMLTV</MudLink>
                 <MudLink Color="Color.Primary" Href="docs" Target="_blank" Underline="Underline.None" Style="font-weight: bold">API</MudLink>
@@ -210,6 +214,10 @@
                 <MudContainer Style="text-align: right" Class="mr-6">
                     <MudText Typo="Typo.body2">ErsatzTV Version</MudText>
                     <MudText Typo="Typo.body2" Color="Color.Info">@InfoVersion</MudText>
+                    @if (BuildConfiguration != "release")
+                    {
+                        <MudText Typo="Typo.body2" Color="Color.Warning">@BuildConfiguration</MudText>
+                    }
                 </MudContainer>
             </MudNavMenu>
         </MudDrawer>
@@ -221,6 +229,7 @@
 
 @code {
     private static readonly string InfoVersion = Assembly.GetEntryAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown";
+    private static readonly string BuildConfiguration = Assembly.GetEntryAssembly().GetCustomAttribute<AssemblyConfigurationAttribute>()?.Configuration?.ToLower() ?? "unset";
 
     private CancellationTokenSource _cts;
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,11 +40,12 @@ COPY ErsatzTV.Infrastructure.Sqlite/. ./ErsatzTV.Infrastructure.Sqlite/
 COPY ErsatzTV.Infrastructure.MySql/. ./ErsatzTV.Infrastructure.MySql/
 COPY ErsatzTV.Scanner/. ./ErsatzTV.Scanner/
 ARG INFO_VERSION="unknown"
+ARG BUILD_CONFIG="release"
 WORKDIR /source/ErsatzTV.Scanner
-RUN dotnet publish ErsatzTV.Scanner.csproj -c release -o /app -r linux-x64 --self-contained false --no-restore /p:DebugType=Embedded /p:InformationalVersion=${INFO_VERSION}
+RUN dotnet publish ErsatzTV.Scanner.csproj -c ${BUILD_CONFIG} -o /app -r linux-x64 --self-contained false --no-restore /p:DebugType=Embedded /p:InformationalVersion=${INFO_VERSION}
 WORKDIR /source/ErsatzTV
 RUN sed -i '/Scanner/d' ErsatzTV.csproj
-RUN dotnet publish ErsatzTV.csproj -c release -o /app -r linux-x64 --self-contained false --no-restore /p:DebugType=Embedded /p:InformationalVersion=${INFO_VERSION}
+RUN dotnet publish ErsatzTV.csproj -c ${BUILD_CONFIG} -o /app -r linux-x64 --self-contained false --no-restore /p:DebugType=Embedded /p:InformationalVersion=${INFO_VERSION}
 
 # final stage/image
 FROM runtime-base

--- a/docker/arm32v7/Dockerfile
+++ b/docker/arm32v7/Dockerfile
@@ -32,10 +32,11 @@ COPY ErsatzTV.Infrastructure.MySql/. ./ErsatzTV.Infrastructure.MySql/
 COPY ErsatzTV.Scanner/. ./ErsatzTV.Scanner/
 WORKDIR /source/ErsatzTV.Scanner
 ARG INFO_VERSION="unknown"
-RUN dotnet publish ErsatzTV.Scanner.csproj --framework net9.0 -c release -o /app --runtime linux-arm --no-self-contained --no-restore -p:DebugType=Embedded -p:PublishSingleFile=false -p:PublishTrimmed=false -p:InformationalVersion=${INFO_VERSION}
+ARG BUILD_CONFIG="release"
+RUN dotnet publish ErsatzTV.Scanner.csproj --framework net9.0 -c ${BUILD_CONFIG} -o /app --runtime linux-arm --no-self-contained --no-restore -p:DebugType=Embedded -p:PublishSingleFile=false -p:PublishTrimmed=false -p:InformationalVersion=${INFO_VERSION}
 WORKDIR /source/ErsatzTV
 RUN sed -i '/Scanner/d' ErsatzTV.csproj
-RUN dotnet publish ErsatzTV.csproj --framework net9.0 -c release -o /app --runtime linux-arm --no-self-contained --no-restore -p:DebugType=Embedded -p:PublishSingleFile=false -p:PublishTrimmed=false -p:InformationalVersion=${INFO_VERSION}
+RUN dotnet publish ErsatzTV.csproj --framework net9.0 -c ${BUILD_CONFIG} -o /app --runtime linux-arm --no-self-contained --no-restore -p:DebugType=Embedded -p:PublishSingleFile=false -p:PublishTrimmed=false -p:InformationalVersion=${INFO_VERSION}
 
 # final stage/image
 FROM runtime-base

--- a/docker/arm64/Dockerfile
+++ b/docker/arm64/Dockerfile
@@ -32,7 +32,8 @@ COPY ErsatzTV.Infrastructure.MySql/. ./ErsatzTV.Infrastructure.MySql/
 COPY ErsatzTV.Scanner/. ./ErsatzTV.Scanner/
 WORKDIR /source/ErsatzTV.Scanner
 ARG INFO_VERSION="unknown"
-RUN dotnet publish ErsatzTV.Scanner.csproj --framework net9.0 -c release -o /app --runtime linux-arm64 --no-self-contained --no-restore -p:DebugType=Embedded -p:PublishSingleFile=false -p:PublishTrimmed=false -p:InformationalVersion=${INFO_VERSION}
+ARG BUILD_CONFIG="release"
+RUN dotnet publish ErsatzTV.Scanner.csproj --framework net9.0 -c ${BUILD_CONFIG} -o /app --runtime linux-arm64 --no-self-contained --no-restore -p:DebugType=Embedded -p:PublishSingleFile=false -p:PublishTrimmed=false -p:InformationalVersion=${INFO_VERSION}
 WORKDIR /source/ErsatzTV
 RUN sed -i '/Scanner/d' ErsatzTV.csproj
 RUN dotnet publish ErsatzTV.csproj --framework net9.0 -c ${BUILD_CONFIG} -o /app --runtime linux-arm64 --no-self-contained --no-restore -p:DebugType=Embedded -p:PublishSingleFile=false -p:PublishTrimmed=false -p:InformationalVersion=${INFO_VERSION}

--- a/docker/arm64/Dockerfile
+++ b/docker/arm64/Dockerfile
@@ -35,7 +35,7 @@ ARG INFO_VERSION="unknown"
 RUN dotnet publish ErsatzTV.Scanner.csproj --framework net9.0 -c release -o /app --runtime linux-arm64 --no-self-contained --no-restore -p:DebugType=Embedded -p:PublishSingleFile=false -p:PublishTrimmed=false -p:InformationalVersion=${INFO_VERSION}
 WORKDIR /source/ErsatzTV
 RUN sed -i '/Scanner/d' ErsatzTV.csproj
-RUN dotnet publish ErsatzTV.csproj --framework net9.0 -c release -o /app --runtime linux-arm64 --no-self-contained --no-restore -p:DebugType=Embedded -p:PublishSingleFile=false -p:PublishTrimmed=false -p:InformationalVersion=${INFO_VERSION}
+RUN dotnet publish ErsatzTV.csproj --framework net9.0 -c ${BUILD_CONFIG} -o /app --runtime linux-arm64 --no-self-contained --no-restore -p:DebugType=Embedded -p:PublishSingleFile=false -p:PublishTrimmed=false -p:InformationalVersion=${INFO_VERSION}
 
 # final stage/image
 FROM runtime-base


### PR DESCRIPTION
This PR adds the following additional elements to the page when the .NET Build Configuration (e.g. `-c release)` is not "release":

- Hostname in HTML `<title>`
- Hostname in main navigation header
- Build configuration below the Version in the left sidebar

Example - changes highlighted with red box:
<img width="1068" height="826" alt="ErsatzTV display-buildconfig" src="https://github.com/user-attachments/assets/ef33464a-25b1-44f6-8edb-c18a9f5b6527" />
