### PR TITLE
Emby: accept non-File protocols for Movie items (fixes #2482)

### DIFF
--- a/ErsatzTV.Infrastructure/Emby/EmbyApiClient.cs
+++ b/ErsatzTV.Infrastructure/Emby/EmbyApiClient.cs
@@ -379,7 +379,7 @@ public class EmbyApiClient : IEmbyApiClient
     {
         try
         {
-            if (item.MediaSources.Any(ms => ms.Protocol != "File"))
+            if (item.MediaSources is null || item.MediaSources.Count == 0)
             {
                 return None;
             }


### PR DESCRIPTION
Emby often returns MediaSources[0].Protocol="Http" for valid items. The old check Any(ms => ms.Protocol != "File") drops those movies (and even drops mixed File+Http). TV ingestion already tolerates this; this change aligns Movies with TV. Scanner already supports remote streaming and will mark items RemoteOnly when no local file exists.